### PR TITLE
Fixed README.md filename

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -5,7 +5,7 @@
     "author": "Jiri Trecak",
     "organization": "Supernova",
     "source_dir": "src",
-    "version": "1.0",
+    "version": "1.0.1",
     "usesBrands": false,
     "config": {
         "sources": "sources.json",

--- a/output.json
+++ b/output.json
@@ -6,7 +6,7 @@
         },
         {
             "invoke": "readme_page.pr",
-            "write_to": "readme.md",
+            "write_to": "README.md",
             "comment": "Create entrypoint for the documentation. Will link to all other pages inside the docs"
         }
     ],


### PR DESCRIPTION
It was `readme.md` which cause issues with Github, so it's now correctly `README.md`